### PR TITLE
Correctly load config on fist creation

### DIFF
--- a/Editor/MultiSceneToolsConfig_StartupInitializer.cs
+++ b/Editor/MultiSceneToolsConfig_StartupInitializer.cs
@@ -37,7 +37,7 @@ namespace HH.MultiSceneToolsEditor
                 typeof(MultiSceneToolsConfig));
 
 
-            if(config == null)            
+            if(config == null)
             {
                 if(!Directory.Exists(configPath)) 
                     Directory.CreateDirectory(configPath);
@@ -51,6 +51,9 @@ namespace HH.MultiSceneToolsEditor
                 AssetDatabase.SaveAssets();
 
                 Debug.LogWarning("Created config ScriptableObject at: " + configPath + configName);
+                config = (MultiSceneToolsConfig)AssetDatabase.LoadAssetAtPath(
+                    configPath + configName, 
+                    typeof(MultiSceneToolsConfig));
             }
             else
                 config.setInstance(config);

--- a/Editor/MultiSceneToolsConfig_StartupInitializer.cs
+++ b/Editor/MultiSceneToolsConfig_StartupInitializer.cs
@@ -51,6 +51,7 @@ namespace HH.MultiSceneToolsEditor
                 AssetDatabase.SaveAssets();
 
                 Debug.LogWarning("Created config ScriptableObject at: " + configPath + configName);
+                // Make sure to load the created config so we can start using it
                 config = (MultiSceneToolsConfig)AssetDatabase.LoadAssetAtPath(
                     configPath + configName, 
                     typeof(MultiSceneToolsConfig));


### PR DESCRIPTION
Fix #2 

# Changelog
- When creating the config file for the first time, it was never loaded which caused a nullref on line 58
- This makes sure to correctly load the config in this codepath