### PR TITLE
Make editor assembly only compile on editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Made editor assembly only compile on Unity Editor platform.
+
 # Version 0.2.6  -  28/02/2023
 
 - Made some object fields read only

--- a/Editor/MultiSceneToolsConfig_Editor.cs
+++ b/Editor/MultiSceneToolsConfig_Editor.cs
@@ -16,7 +16,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if UNITY_EDITOR
 using UnityEngine;
 using UnityEditor;
 using HH.MultiSceneTools;
@@ -108,5 +107,3 @@ namespace HH.MultiSceneToolsEditor
         }
     }
 }
-
-#endif

--- a/Editor/MultiSceneToolsConfig_StartupInitializer.cs
+++ b/Editor/MultiSceneToolsConfig_StartupInitializer.cs
@@ -16,7 +16,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 using HH.MultiSceneTools;
@@ -60,4 +59,3 @@ namespace HH.MultiSceneToolsEditor
         }
     }
 }
-#endif

--- a/Editor/MultiSceneToolsEditor.asmdef
+++ b/Editor/MultiSceneToolsEditor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:3d61be0c52ad2ee409d26dae681f6697"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Editor/SceneCollection_Editor.cs
+++ b/Editor/SceneCollection_Editor.cs
@@ -16,8 +16,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if UNITY_EDITOR
-
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor;
@@ -76,4 +74,3 @@ namespace HH.MultiSceneToolsEditor
         }
     }
 }
-#endif

--- a/Editor/SceneManager_EditorWindow.cs
+++ b/Editor/SceneManager_EditorWindow.cs
@@ -16,8 +16,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if UNITY_EDITOR
-
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor;
@@ -408,4 +406,3 @@ namespace HH.MultiSceneToolsEditor
         }
     }
 }
-#endif

--- a/Editor/SceneTransition_Editor.cs
+++ b/Editor/SceneTransition_Editor.cs
@@ -16,8 +16,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if UNITY_EDITOR
-
 using UnityEditor;
 using HH.MultiSceneTools.Examples;
 
@@ -43,4 +41,3 @@ namespace HH.MultiSceneToolsEditor
         }
     }
 }
-#endif


### PR DESCRIPTION
# Why
- The correct way to work with Assemblies is to make sure they only compile for the platforms they are intended for. 
- This ensures that an assembly made to work _not with the editor_ (runtime only) don't accidentally depend on the editor assembly.
- This also ensures that all scripts within this assembly only ever are compiled on the editor platform and no longer need the whole file wrapped with the `#if UNITY_EDITOR` preprocessor

# Changelog
- The `MultiSceneToolsEditor` assembly now only compiles on Unity Editor platform
- Removed (now redundant) `#if UNITY_EDITOR` preprocessors from the editor scripts
- Added changelog since this would be potentially breaking change if anyone using this would incorrectly depend on the editor assembly

![image](https://user-images.githubusercontent.com/13300393/229272139-ba1fae08-93ea-46da-b430-4c26bed7ceac.png)
